### PR TITLE
Fixed loop in tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# easy-template-x
+# easy-template-x Fork
+This is a fork of the awesome [easy-template-x](https://github.com/alonrbar/easy-template-x) project with some additional bugfixes which haven't been integrated yet into the main repository.
+
+# easy-template-x Original
 
 Generate docx documents from templates, in Node or in the browser.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "easy-template-x",
+  "name": "@bbitgmbh/easy-template-x",
   "version": "3.2.0",
   "description": "Generate docx documents from templates, in Node or in the browser.",
   "keywords": [
@@ -12,13 +12,13 @@
   ],
   "author": "Alon Bar",
   "license": "MIT",
-  "homepage": "https://github.com/alonrbar/easy-template-x",
+  "homepage": "https://github.com/bbitgmbh/easy-template-x",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alonrbar/easy-template-x.git"
+    "url": "https://github.com/bbitgmbh/easy-template-x.git"
   },
   "bugs": {
-    "url": "https://github.com/alonrbar/easy-template-x/issues"
+    "url": "https://github.com/bbitgmbh/easy-template-x/issues"
   },
   "main": "dist/cjs/easy-template-x.js",
   "module": "dist/es/easy-template-x.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbitgmbh/easy-template-x",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Generate docx documents from templates, in Node or in the browser.",
   "keywords": [
     "docx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbitgmbh/easy-template-x",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Generate docx documents from templates, in Node or in the browser.",
   "keywords": [
     "docx",

--- a/src/plugins/loop/loopPlugin.ts
+++ b/src/plugins/loop/loopPlugin.ts
@@ -58,7 +58,7 @@ export class LoopPlugin extends TemplatePlugin {
         const compiledNodes = await this.compile(isCondition, repeatedNodes, data, context);
 
         // merge back to the document
-        loopStrategy.mergeBack(compiledNodes, firstNode, lastNode);
+        loopStrategy.mergeBack(compiledNodes, firstNode, lastNode, nodesToRepeat);
     }
 
     private repeat(nodes: XmlNode[], times: number): XmlNode[][] {

--- a/src/plugins/loop/strategy/iLoopStrategy.ts
+++ b/src/plugins/loop/strategy/iLoopStrategy.ts
@@ -10,7 +10,7 @@ export interface ILoopStrategy {
 
     splitBefore(openTag: Tag, closeTag: Tag): SplitBeforeResult;
 
-    mergeBack(compiledNodes: XmlNode[][], firstNode: XmlNode, lastNode: XmlNode): void;
+    mergeBack(compiledNodes: XmlNode[][], firstNode: XmlNode, lastNode: XmlNode, nodesToRepeat: XmlNode[]): void;
 }
 
 export interface SplitBeforeResult {

--- a/src/plugins/loop/strategy/loopTableStrategy.ts
+++ b/src/plugins/loop/strategy/loopTableStrategy.ts
@@ -35,18 +35,15 @@ export class LoopTableStrategy implements ILoopStrategy {
         };
     }
 
-    public mergeBack(rowGroups: XmlNode[][], firstRow: XmlNode, lastRow: XmlNode): void {
-
+    public mergeBack(rowGroups: XmlNode[][], firstRow: XmlNode, lastRow: XmlNode, nodesToRepeat: XmlNode[]): void {
         for (const curRowsGroup of rowGroups) {
             for (const row of curRowsGroup) {
                 XmlNode.insertBefore(row, lastRow);
             }
         }
 
-        // remove the old rows
-        XmlNode.remove(firstRow);
-        if (firstRow !== lastRow) {
-            XmlNode.remove(lastRow);
+        for (const node of nodesToRepeat) {
+            XmlNode.remove(node);
         }
     }
 }


### PR DESCRIPTION
When iterating over an array within a table with multiple if-statements, some rows were not removed as expected. This PR will fix this.

Previous result:

![Screenshot 2023-06-05 at 15 02 38](https://github.com/alonrbar/easy-template-x/assets/5129086/bf7505c4-f91a-4c39-8628-d9569c444483)

New result:

![Screenshot 2023-06-05 at 15 05 25](https://github.com/alonrbar/easy-template-x/assets/5129086/739e7f87-a530-4504-980d-49e3665988d3)

As you can see in the previous result, the rows starting with `{#type ==` should not appear in the output.

Would be nice to have this merged so we don't need to keep a separate loop plugin within our projects :)

Thanks a lot!

