### PR TITLE
Fix deformation in word/_rels/document.xml.rels when calling parseRelsFile

### DIFF
--- a/src/office/relsFile.ts
+++ b/src/office/relsFile.ts
@@ -139,11 +139,22 @@ export class RelsFile {
 
             // store rel
             const rel = Relationship.fromXml(relNode as XmlGeneralNode);
+
+            // normalize target to be relative to the part directory
+            const typeAttr = attributes['Type'];
+            let targetAttr = Relationship.normalizeRelTarget(attributes['Target']);
+            if (targetAttr && this.partDir && targetAttr.startsWith(this.partDir + '/')) {
+                targetAttr = targetAttr.substring(this.partDir.length + 1);
+            }
+
+            // keep the normalized target on the relationship object
+            if (targetAttr) {
+                rel.target = targetAttr;
+            }
+
             this.rels[idAttr] = rel;
 
             // create rel target lookup
-            const typeAttr = attributes['Type'];
-            const targetAttr = Relationship.normalizeRelTarget(attributes['Target']);
             if (typeAttr && targetAttr) {
                 const relTargetKey = this.getRelTargetKey(typeAttr, targetAttr);
                 this.relTargets[relTargetKey] = idAttr;

--- a/test/fixtures/rels.tests.ts
+++ b/test/fixtures/rels.tests.ts
@@ -1,4 +1,5 @@
 import { TemplateHandler } from 'src/templateHandler';
+import { Zip } from 'src/zip';
 import { readFixture } from './fixtureUtils';
 
 describe('rels fixture', () => {
@@ -11,5 +12,26 @@ describe('rels fixture', () => {
 
         const handler = new TemplateHandler();
         await handler.process(template, data);
+    });
+
+    it("writes part-level rels with relative targets (no word/ prefix)", async () => {
+
+        const template = readFixture("rels variations.docx");
+
+        const handler = new TemplateHandler();
+        const out = await handler.process(template, {});
+
+        const zip = await Zip.load(out);
+        const relsObj = zip.getFile('word/_rels/document.xml.rels');
+        expect(relsObj).toBeTruthy();
+
+        const relsXml = await relsObj.getContentText();
+        expect(relsXml).toBeTruthy();
+
+        // Ensure we don't write part-level relationships with Target="word/..."
+        expect(relsXml).not.toMatch('Target="word/');
+
+        // Sanity: styles relationship should be present and relative
+        expect(relsXml).toMatch('Target="styles.xml"');
     });
 });


### PR DESCRIPTION
Problem:
When parsing `word/_rels/document.xml.rels`, targets were kept with a `word/` prefix (absolute-like paths after removing a leading `/`). On export, these were written back as-is, producing invalid part-level relationships such as `Target="word/styles.xml"` instead of the required `Target="styles.xml"`.
This caused broken links (headers/footers/styles/etc.) after import/export.

Discovery:
- Used `test/fixtures/rels.tests.ts` to generate a DOCX (modified to write docx file on disk).
- Opening the output in MS Word triggered a repair dialog, and after repair the document styles were broken.
- Commenting the parts enumeration in `Docx.getContentParts()` (the `mainDocument.getPartsByType(...)` call) avoided rewriting `.rels`, and the issue disappeared.

Change:
- In `RelsFile.parseRelsFile()`, after reading a relationship:
  - Normalize the target (remove leading `/`).
  - If a `partDir` exists and the target starts with `partDir/`, strip the prefix so the target is stored relative to the part directory.
  - Persist the normalized target on the `Relationship` and use it for the lookup map.

Impact:
- Round-tripping a DOCX no longer corrupts `word/_rels/document.xml.rels`.
- Calls that enumerate parts (e.g. `Docx.getContentParts()`) no longer trigger relationship deformation.
- Root `_rels/.rels` remains unaffected (no `partDir`).

No breaking changes.