### PR TITLE
Fix text replacement for leading newline

### DIFF
--- a/src/plugins/text/textPlugin.ts
+++ b/src/plugins/text/textPlugin.ts
@@ -79,7 +79,7 @@ export class TextPlugin extends TemplatePlugin {
         const namespace = runNode.nodeName.split(':')[0];
 
         // First line
-        if (lines[0]) {
+        if (typeof lines[0] === 'string') {
             textNode.textContent = lines[0];
         }
 

--- a/test/fixtures/text.tests.ts
+++ b/test/fixtures/text.tests.ts
@@ -120,6 +120,28 @@ describe('text tag fixtures', () => {
         // writeTempFile('simple - multiline - output.docx', doc);
     });
 
+    it("preserves leading newlines in text replacement", async () => {
+
+        const handler = new TemplateHandler();
+
+        // load the template
+
+        const template: Buffer = readFixture("simple.docx");
+        const templateText = await handler.getText(template);
+        expect(templateText.trim()).toEqual("{simple_prop}");
+
+        // replace tags
+
+        const data = {
+            simple_prop: '\nleading newline'
+        };
+
+        const doc = await handler.process(template, data);
+
+        const docText = await handler.getText(doc);
+        expect(docText.trim()).toEqual("leading newline");
+    });
+
     it("escapes xml special characters", async () => {
 
         const handler = new TemplateHandler();


### PR DESCRIPTION
This PR addresses a bug where leading newlines in multiline text replacements were not properly preserved in the document structure. The issue occurred because the condition for setting the first line's content was falsy for empty strings, causing the original text node content to remain unchanged instead of being cleared.