### PR TITLE
Throw a clear error when loop tags span different containers

### DIFF
--- a/src/plugins/loop/strategy/loopContentStrategy.tests.ts
+++ b/src/plugins/loop/strategy/loopContentStrategy.tests.ts
@@ -1,4 +1,4 @@
-import { TagDisposition, TagPlacement, TextNodeTag, XmlTextNode } from "src";
+import { TagDisposition, TagPlacement, TemplateSyntaxError, TextNodeTag, XmlTextNode } from "src";
 import { LoopContentStrategy } from "./loopContentStrategy";
 import { parseXml } from "test/testUtils";
 import { describe, expect, it } from "vitest";
@@ -59,6 +59,62 @@ describe(LoopContentStrategy, () => {
             const textNode = wordTextNode?.childNodes?.[0] as XmlTextNode;
             expect(textNode).toBeTruthy();
             expect(textNode.textContent).toEqual('before');
+        });
+
+        it("throws a clear error when the open and close tags are not in the same container", () => {
+
+            //
+            // prepare
+            //
+
+            const body = parseXml(`
+                <w:body>
+                    <w:p>
+                        <w:r>
+                            <w:t>{#loop}</w:t>
+                        </w:r>
+                    </w:p>
+                    <w:tbl>
+                        <w:tr>
+                            <w:tc>
+                                <w:p>
+                                    <w:r>
+                                        <w:t>{/loop}</w:t>
+                                    </w:r>
+                                </w:p>
+                            </w:tc>
+                        </w:tr>
+                    </w:tbl>
+                </w:body>
+            `);
+
+            const openParagraph = body.childNodes[0];
+            const closeParagraph = body.childNodes[1].childNodes[0].childNodes[0].childNodes[0];
+
+            const openTag: TextNodeTag = {
+                name: 'loop',
+                placement: TagPlacement.TextNode,
+                disposition: TagDisposition.Open,
+                rawText: '{#loop}',
+                xmlTextNode: openParagraph.childNodes[0].childNodes[0].childNodes[0] as XmlTextNode
+            };
+            const closeTag: TextNodeTag = {
+                name: 'loop',
+                placement: TagPlacement.TextNode,
+                disposition: TagDisposition.Close,
+                rawText: '{/loop}',
+                xmlTextNode: closeParagraph.childNodes[0].childNodes[0].childNodes[0] as XmlTextNode
+            };
+            expect(openTag.xmlTextNode.textContent).toEqual('{#loop}');
+            expect(closeTag.xmlTextNode.textContent).toEqual('{/loop}');
+
+            const strategy = new LoopContentStrategy();
+
+            //
+            // test
+            //
+
+            expect(() => strategy.splitBefore(openTag, closeTag)).toThrow(TemplateSyntaxError);
         });
     });
 });

--- a/src/plugins/loop/strategy/loopContentStrategy.ts
+++ b/src/plugins/loop/strategy/loopContentStrategy.ts
@@ -1,4 +1,5 @@
 import { TextNodeTag } from "src/compilation";
+import { TemplateSyntaxError } from "src/errors";
 import { officeMarkup } from "src/office";
 import { xml, XmlNode } from "src/xml";
 import { ILoopStrategy, SplitBeforeResult } from "./iLoopStrategy";
@@ -15,6 +16,19 @@ export class LoopContentStrategy implements ILoopStrategy {
         let firstParagraph: XmlNode = officeMarkup.query.containingParagraphNode(openTag.xmlTextNode);
         let lastParagraph: XmlNode = officeMarkup.query.containingParagraphNode(closeTag.xmlTextNode);
         const areSame = (firstParagraph === lastParagraph);
+
+        // The open and close tags must live in paragraphs that are siblings of
+        // the same parent. Otherwise the loop spans a structural boundary (for
+        // instance, one tag is inside a table cell and the other is not) and we
+        // would fail later on while trying to collect the nodes in between with
+        // an obscure "Cannot read properties of undefined (reading
+        // 'nextSibling')" error. Fail fast with a clear message instead.
+        if (!areSame && firstParagraph.parentNode !== lastParagraph.parentNode) {
+            throw new TemplateSyntaxError(
+                `Loop open and close tags are not placed in the same container: "${openTag.rawText}" and "${closeTag.rawText}". ` +
+                `Make sure both tags are at the same level (for example, both outside of a table, or both within the same table cell).`
+            );
+        }
 
         // Split first paragraph
         const removeTextNode = true;


### PR DESCRIPTION
## Problem

Processing certain templates crashed with an opaque internal error:

```
TypeError: Cannot read properties of undefined (reading 'nextSibling')
    at Modify.removeSiblings (.../easy-template-x.mjs:966:19)
    at LoopContentStrategy.splitBefore (.../easy-template-x.mjs:3484:36)
    at LoopPlugin.containerTagReplacements (.../easy-template-x.mjs:3752:22)
    ...
```

## Root cause

`LoopContentStrategy.splitBefore` (the catch-all loop strategy) collects the paragraphs between the loop's open and close tags via `xml.modify.removeSiblings(firstParagraph, lastParagraph)`. That helper walks the `nextSibling` chain from `firstParagraph` looking for `lastParagraph`, assuming the two are siblings under the same parent.

When the open and close tags are **not** in paragraphs sharing a parent — e.g. the open tag is in a body-level paragraph and the close tag is inside a table cell — `lastParagraph` is never reached, the walk falls off the end of the sibling list (`from` becomes `undefined`), and `undefined.nextSibling` throws the error above deep in the XML layer.

## Fix

Detect the mismatch up front in `LoopContentStrategy.splitBefore` and throw a descriptive `TemplateSyntaxError` instead of letting `removeSiblings` crash:

> Loop open and close tags are not placed in the same container: "{#loop}" and "{/loop}". Make sure both tags are at the same level (for example, both outside of a table, or both within the same table cell).

This mirrors the existing handling in `LoopTableRowsStrategy`, which already throws a `TemplateSyntaxError` when loop tags span different tables.

## Tests

- Added a test asserting `splitBefore` throws `TemplateSyntaxError` when the open tag is outside a table and the close tag is inside a table cell.
- Full suite passes (154 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBgfCtfiLwQxzhLpiSoJjW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBgfCtfiLwQxzhLpiSoJjW)_